### PR TITLE
トップページ、ログインページ、新規会員登録ページ遷移機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_signup.scss
+++ b/app/assets/stylesheets/modules/_signup.scss
@@ -151,7 +151,7 @@
   border: 1px solid #3ccace;
   border-radius: 4px;
   margin-top: 40px;
-  color: 　var(--white-color);
+  color: var(--white-color);
   justify-content: center;
   font-size: 14px;
 }

--- a/app/views/indexes/_header.html.haml
+++ b/app/views/indexes/_header.html.haml
@@ -22,10 +22,11 @@
         = link_to "#", class: "Search-menu__brand--text" do
           ブランドから探す
     .Btn
-      .Btn__login
+      = link_to "/users/sign_in", class: "Btn__login" do
         ログイン
-      .Btn__join
+      = link_to "/users/sign_up", class: "Btn__join" do
         新規会員登録
+        
   .Exhibit
   = link_to "#", class: "Exhibit" do
     .Exhibit__text 出品する

--- a/app/views/indexes/_header.html.haml
+++ b/app/views/indexes/_header.html.haml
@@ -22,9 +22,9 @@
         = link_to "#", class: "Search-menu__brand--text" do
           ブランドから探す
     .Btn
-      = link_to "/users/sign_in", class: "Btn__login" do
+      = link_to new_user_session_path, class: "Btn__login" do
         ログイン
-      = link_to "/users/sign_up", class: "Btn__join" do
+      = link_to new_user_registration_path, class: "Btn__join" do
         新規会員登録
         
   .Exhibit


### PR DESCRIPTION
# what
ユーザーがトップページからログインページ、新規会員登録ページに移動できるようトップページに配置されたログイン、新規会員登録ボタンにそれぞれのページに遷移できるようリンクを挿入する。また、ログイン、新規会員登録ページの上部と下部に配置されたアプリロゴマークをクリックすることで、トップページに移動できるようにリンクを挿入する。

# why
URL入力によるページ遷移よりもボタン、アイコンクリックでのページ遷移の方がユーザビリティーが向上するから。